### PR TITLE
Fix chunk file match dependency on [name]

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -31,11 +31,11 @@ module.exports = function PurifyPlugin(options) {
         compilation.plugin('additional-assets', (cb) => {
           // Go through chunks and purify as configured
           compilation.chunks.forEach(
-            ({ name: chunkName, modules }) => {
+            ({ name: chunkName, files, modules }) => {
               const assetsToPurify = search.assets(
                 compilation.assets, options.styleExtensions
               ).filter(
-                asset => asset.name.indexOf(chunkName) >= 0
+                asset => files.indexOf(asset.name) >= 0
               );
 
               output(() => [


### PR DESCRIPTION
Fix for issue #85 

Previously, `compilation.chunks` require `[name]` to be present in `filename` out of `ExtractTextPlugin`. Otherwise the CSS asset fails to match, and is omitted. This fix now uses full `filename` match instead.