### PR TITLE
feat - Add strict validation against `paths`

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,4 @@
+import fs from 'fs';
 import purify from 'purify-css';
 import { ConcatSource } from 'webpack-sources';
 import * as parse from './parse';
@@ -21,6 +22,10 @@ module.exports = function PurifyPlugin(options) {
 
       compiler.plugin('this-compilation', (compilation) => {
         const entryPaths = parse.entryPaths(options.paths);
+
+        parse.flatten(entryPaths).forEach((p) => {
+          if (!fs.existsSync(p)) throw new Error(`Path ${p} does not exist.`);
+        });
 
         // Output debug information through a callback pattern
         // to avoid unnecessary processing

--- a/src/parse.js
+++ b/src/parse.js
@@ -9,6 +9,12 @@ function parseEntryPaths(paths) {
   return ret;
 }
 
+function flattenEntryPaths(paths) {
+  return Array.isArray(paths) ?
+    paths :
+    Object.keys(paths).reduce((acc, val) => [...acc, ...paths[val]], []);
+}
+
 function parseEntries(paths, chunkName) {
   if (Array.isArray(paths)) {
     return paths;
@@ -25,5 +31,6 @@ function parseEntries(paths, chunkName) {
 
 module.exports = {
   entryPaths: parseEntryPaths,
+  flatten: flattenEntryPaths,
   entries: parseEntries
 };

--- a/src/parse.test.js
+++ b/src/parse.test.js
@@ -19,6 +19,20 @@ describe('Parse entry paths', function () {
   });
 });
 
+describe('Flatten entry paths', function () {
+  it('returns an array as itself', function () {
+    const a = ['a', 'b', 'c'];
+
+    assert.deepEqual(parse.flatten(a), a);
+  });
+
+  it('returns an object of arrays as one flat array', function () {
+    const o = { a: ['a', 'b'], b: ['c', 'd'] };
+
+    assert.deepEqual(parse.flatten(o), ['a', 'b', 'c', 'd']);
+  });
+});
+
 describe('Parse entries', function () {
   it('returns paths if there is no chunk name', function () {
     const paths = ['a', 'b', 'c'];


### PR DESCRIPTION
I am not sure which kind of error handling might be appropriate for this case, though. I decided to throw an error, but we might consider to remove the non existing path(s), build anyway and show a warning message.

#77 