### PR TITLE
Allow purifycss-webpack to work with ExtractTextCssPlugin when hash is in CSS asset name

### DIFF
--- a/examples/webpack.parts.js
+++ b/examples/webpack.parts.js
@@ -16,7 +16,7 @@ exports.extractCSS = function extractCSS(paths) {
       ]
     },
     plugins: [
-      new ExtractTextPlugin('[name].css')
+      new ExtractTextPlugin('[name].css?[hash]')
     ]
   };
 };

--- a/src/search.js
+++ b/src/search.js
@@ -10,7 +10,7 @@ function searchAssets(
       if (/\.(css\?).*$/.test(name)) {
         nameCleaned = name.substr(0, name.lastIndexOf('?')); // ignore hash on file like style.css?7ec000f0d0d347
       }
-      extensions.indexOf(path.extname(nameCleaned)) >= 0 && { name, asset: assets[name] }
+      return extensions.indexOf(path.extname(nameCleaned)) >= 0 && { name, asset: assets[name] }
     }
   ).filter(a => a);
 }

--- a/src/search.js
+++ b/src/search.js
@@ -5,12 +5,12 @@ function searchAssets(
   extensions = []
 ) {
   return Object.keys(assets).map(
-    name => {
-      var nameCleaned = name;
+    (name) => {
+      let nameCleaned = name;
       if (/\.(css\?).*$/.test(name)) {
         nameCleaned = name.substr(0, name.lastIndexOf('?')); // ignore hash on file like style.css?7ec000f0d0d347
       }
-      return extensions.indexOf(path.extname(nameCleaned)) >= 0 && { name, asset: assets[name] }
+      return extensions.indexOf(path.extname(nameCleaned)) >= 0 && { name, asset: assets[name] };
     }
   ).filter(a => a);
 }

--- a/src/search.js
+++ b/src/search.js
@@ -5,7 +5,13 @@ function searchAssets(
   extensions = []
 ) {
   return Object.keys(assets).map(
-    name => extensions.indexOf(path.extname(name)) >= 0 && { name, asset: assets[name] }
+    name => {
+      var nameCleaned = name;
+      if (/\.(css\?).*$/.test(name)) {
+        nameCleaned = name.substr(0, name.lastIndexOf('?')); // ignore hash on file like style.css?7ec000f0d0d347
+      }
+      extensions.indexOf(path.extname(nameCleaned)) >= 0 && { name, asset: assets[name] }
+    }
   ).filter(a => a);
 }
 


### PR DESCRIPTION
Allow purifycss-webpack to work with ExtractTextCssPlugin when hash is added to css file name. 

Example: [name].css?[hash] -> style.css?218aa9358a709a5a0a12