### PR TITLE
Drop `styleExtensions`

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,6 @@ This plugin, unlike the original PurifyCSS plugin, provides special features, su
 
 | Property            | Description
 |---------------------|------------
-| `styleExtensions`   | An array of file extensions for determining used classes within style files. Defaults to `['.css']`.
 | `moduleExtensions`  | An array of file extensions for determining used classes within `node_modules`. Defaults to `[]`, but `['.html']` can be useful here.
 | `minimize`          | Enable CSS minification. Alias to `purifyOptions.minify`. Disabled by default.
 | `paths`             | An array of absolute paths or a path to traverse. This also accepts an object (`<entry name> -> <paths>`). It can be a good idea [glob](http://npmjs.org/glob) these.

--- a/examples/webpack.config.js
+++ b/examples/webpack.config.js
@@ -25,8 +25,7 @@ module.exports = [
     parts.purifyCSS({
       verbose: true,
       minimize: true,
-      paths: glob.sync(`${PATHS.app}/*`),
-      styleExtensions: ['.css']
+      paths: glob.sync(`${PATHS.app}/*`)
     })
   ),
   merge(
@@ -46,7 +45,6 @@ module.exports = [
         first: glob.sync(`${PATHS.app}/*`),
         second: glob.sync(`${PATHS.another}/*`)
       },
-      styleExtensions: ['.css']
     })
   )
 ];

--- a/examples/webpack.config.js
+++ b/examples/webpack.config.js
@@ -44,7 +44,7 @@ module.exports = [
       paths: {
         first: glob.sync(`${PATHS.app}/*`),
         second: glob.sync(`${PATHS.another}/*`)
-      },
+      }
     })
   )
 ];

--- a/src/index.js
+++ b/src/index.js
@@ -38,7 +38,7 @@ module.exports = function PurifyPlugin(options) {
           compilation.chunks.forEach(
             ({ name: chunkName, files, modules }) => {
               const assetsToPurify = search.assets(
-                compilation.assets, options.styleExtensions
+                compilation.assets, ['.css']
               ).filter(
                 asset => files.indexOf(asset.name) >= 0
               );

--- a/src/schema.js
+++ b/src/schema.js
@@ -3,13 +3,6 @@ const schema = ({ entry } = {}) => ({
   additionalProperties: false,
   type: 'object',
   properties: {
-    styleExtensions: {
-      type: 'array',
-      items: {
-        type: 'string'
-      },
-      default: ['.css']
-    },
     minimize: {
       type: 'boolean'
     },

--- a/src/validate-options.test.js
+++ b/src/validate-options.test.js
@@ -33,18 +33,6 @@ describe('Validate options', function () {
     assert.ok(result.error);
   });
 
-  it('styleExtensions have defaults', function () {
-    const paths = ['./foo'];
-    const data = { paths };
-
-    // Currently this mutates data with defaults due to ajv design. It
-    // might be a good idea to change that behavior, though.
-    const result = validateOptions(schema(), data);
-
-    assert.deepEqual(data, { paths, styleExtensions: ['.css'] });
-    assert.ok(!result.error);
-  });
-
   it('fails without matching path keys', function () {
     const data = {
       paths: {


### PR DESCRIPTION
### Notable Changes
---
- Breaking change, since schema validation will fail if styleExtensions is still used.

### Issues
---

Closes #90